### PR TITLE
Provide usable initializers for Swift

### DIFF
--- a/FsprgEmbeddedStore/FsprgStoreParameters.h
+++ b/FsprgEmbeddedStore/FsprgStoreParameters.h
@@ -25,8 +25,8 @@ extern NSString * const kFsprgModeTest;
  */
 @interface FsprgStoreParameters : NSObject
 
-@property (assign) BOOL hasContactDefaults;
-@property (copy) NSMutableDictionary *raw;
+@property (nonatomic, assign) BOOL hasContactDefaults;
+@property (nonatomic, copy) NSMutableDictionary *raw;
 
 + (FsprgStoreParameters *)parameters;
 + (FsprgStoreParameters *)parametersWithRaw:(NSMutableDictionary *)aRaw;

--- a/FsprgEmbeddedStore/FsprgStoreParameters.h
+++ b/FsprgEmbeddedStore/FsprgStoreParameters.h
@@ -23,10 +23,10 @@ extern NSString * const kFsprgModeTest;
  * FastSpring store parameters. FsprgStoreParameters is backed by a NSMutableDictionary that
  * can be accessed and modified via the raw and setRaw: methods.
  */
-@interface FsprgStoreParameters : NSObject {
-	BOOL hasContactDefaults;
-	NSMutableDictionary *raw;
-}
+@interface FsprgStoreParameters : NSObject
+
+@property (assign) BOOL hasContactDefaults;
+@property (copy) NSMutableDictionary *raw;
 
 + (FsprgStoreParameters *)parameters;
 + (FsprgStoreParameters *)parametersWithRaw:(NSMutableDictionary *)aRaw;
@@ -34,9 +34,8 @@ extern NSString * const kFsprgModeTest;
 - (NSURLRequest *)toURLRequest;
 - (NSURL *)toURL;
 
-- (id)initWithRaw:(NSMutableDictionary *)aRaw;
-- (NSMutableDictionary *)raw;
-- (void)setRaw:(NSMutableDictionary *)aRaw;
+- (instancetype)init;
+- (instancetype)initWithRaw:(NSMutableDictionary *)aRaw;
 
 /*!
  * Pass a language code via the URL to bypass automatic language detection.

--- a/FsprgEmbeddedStore/FsprgStoreParameters.m
+++ b/FsprgEmbeddedStore/FsprgStoreParameters.m
@@ -62,8 +62,7 @@ static NSMutableDictionary *keyPathsForValuesAffecting;
 
 + (FsprgStoreParameters *)parameters
 {
-	NSMutableDictionary *raw = [NSMutableDictionary dictionaryWithCapacity:15];
-	return [[[FsprgStoreParameters alloc] initWithRaw:raw] autorelease];
+	return [[[FsprgStoreParameters alloc] init] autorelease];
 }
 
 + (FsprgStoreParameters *)parametersWithRaw:(NSMutableDictionary *)aRaw
@@ -81,26 +80,19 @@ static NSMutableDictionary *keyPathsForValuesAffecting;
 	}
 }
 
-- (id)initWithRaw:(NSMutableDictionary *)aRaw
+- (instancetype)init
+{
+    NSMutableDictionary *raw = [NSMutableDictionary dictionaryWithCapacity:15];
+    return [self initWithRaw:raw];
+}
+
+- (instancetype)initWithRaw:(NSMutableDictionary *)aRaw
 {
 	self = [super init];
 	if (self != nil) {
-		[self setRaw:aRaw];
+		_raw = [aRaw mutableCopy];
 	}
 	return self;
-}
-
-- (NSMutableDictionary *)raw
-{
-    return [[raw retain] autorelease]; 
-}
-
-- (void)setRaw:(NSMutableDictionary *)aRaw
-{
-    if (raw != aRaw) {
-        [raw release];
-        raw = [aRaw retain];
-    }
 }
 
 - (NSURLRequest *)toURLRequest


### PR DESCRIPTION
Pull-requesting DivineDominion's pull request for FastSpring (they seem to be lagging). Here's the original description:

Swift, by convention, uses +parameters to provide a default initializer, FsprgStoreParameters(). Although this call did work, the underlying dictionary didn't seem to be retained.

Making the member variables properties and providing a proper convenience initializer solved the issue.
